### PR TITLE
support ColorTypes 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 
 [compat]
-ColorTypes = "0.11"
+ColorTypes = "0.11, 0.12"
 FixedPointNumbers = "0.8"
 FileIO = "1.12.0"
 julia = "1.6"
@@ -17,9 +17,10 @@ julia = "1.6"
 [extras]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [targets]
-test = ["Test", "Downloads", "ImageIO", "p7zip_jll", "Scratch"]
+test = ["Test", "Downloads", "ImageIO", "ImageMagick", "p7zip_jll", "Scratch"]


### PR DESCRIPTION
Required for https://github.com/JuliaPlots/UnicodePlots.jl/pull/392, please release a new version.

cc @KristofferC 